### PR TITLE
Trim trailing whitespace, do not trim final newlines

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -24,4 +24,6 @@
 
     "python.linting.banditEnabled": true,
     "editor.renderWhitespace": "trailing",
+    "files.trimFinalNewlines": false,
+    "files.trimTrailingWhitespace": true,
 }


### PR DESCRIPTION
# Reviewer Checklist
https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md

# Related Issues
fixes NRLMMD-GEOIPS/.vscode#1

# Testing Instructions
See that final newlines are not trimmed, and trailing whitespace is trimmed from VSCode on save.

# Summary
Added 2 lines to workspace settings.json - 
* don't trim final newlines
* trim trailing whitespace

# Output
VSCode removed trailing whitespace, and did not remove final newlines when I saved a file.